### PR TITLE
Stop using deprecated tycho-eclipserun-plugin appArgLine

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -92,7 +92,19 @@
                 <configuration>
                   <skip>false</skip>
                   <!-- call buildDoc.xml -->
-                  <appArgLine>-consolelog -debug -data target/workspace -application org.eclipse.ant.core.antRunner -quiet -buildfile buildDoc.xml -Dbasedir.properties=cbi_basedirs.properties -Declipse.javadoc=${eclipse.javadoc}</appArgLine>
+                  <applicationsArgs>
+	                  <args>-consolelog</args>
+	                  <args>-debug</args>
+	                  <args>-data</args>
+	                  <args>target/workspace</args>
+	                  <args>-application</args>
+	                  <args>org.eclipse.ant.core.antRunner</args>
+	                  <args>-quiet</args>
+	                  <args>-buildfile</args>
+	                  <args>buildDoc.xml</args>
+	                  <args>-Dbasedir.properties=cbi_basedirs.properties</args>
+	                  <args>-Declipse.javadoc=${eclipse.javadoc}</args>
+                  </applicationsArgs>
                   <dependencies>
                     <!-- list of bundles that we need -->
                     <dependency>

--- a/bundles/org.eclipse.jdt.doc.user/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.user/pom.xml
@@ -42,7 +42,16 @@
                 <phase>compile</phase>
                 <configuration>
                   <skip>false</skip>
-                  <appArgLine>-consolelog -debug -application org.eclipse.ant.core.antRunner -quiet -buildfile build.xml build.index</appArgLine>
+                  <applicationsArgs>
+	                  <args>-consolelog</args>
+	                  <args>-debug</args>
+	                  <args>-application</args>
+	                  <args>org.eclipse.ant.core.antRunner</args>
+	                  <args>-quiet</args>
+	                  <args>-buildfile</args>
+	                  <args>build.xml</args>
+	                  <args>build.index</args>
+                  </applicationsArgs>
                   <dependencies>
                     <dependency>
                       <artifactId>org.eclipse.osgi.compatibility.state</artifactId>

--- a/bundles/org.eclipse.pde.doc.user/pom.xml
+++ b/bundles/org.eclipse.pde.doc.user/pom.xml
@@ -92,7 +92,19 @@
                 <configuration>
                   <skip>false</skip>
                   <!-- call buildDoc.xml -->
-                  <appArgLine>-consolelog -debug -data target/workspace -application org.eclipse.ant.core.antRunner -quiet -buildfile buildDoc.xml -Dbasedir.properties=cbi_basedirs.properties  -Declipse.javadoc=${eclipse.javadoc}</appArgLine>
+                  <applicationsArgs>
+	                  <args>-consolelog</args>
+	                  <args>-debug</args>
+	                  <args>-data</args>
+	                  <args>target/workspace</args>
+	                  <args>-application</args>
+	                  <args>org.eclipse.ant.core.antRunner</args>
+	                  <args>-quiet</args>
+	                  <args>-buildfile</args>
+	                  <args>buildDoc.xml</args>
+	                  <args>-Dbasedir.properties=cbi_basedirs.properties</args>
+	                  <args>-Declipse.javadoc=${eclipse.javadoc}</args>
+                  </applicationsArgs>
                   <dependencies>
                     <dependency>
                       <artifactId>org.eclipse.osgi.compatibility.state</artifactId>

--- a/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -259,7 +259,19 @@
                 <configuration>
                   <skip>false</skip>
                   <!-- call buildDoc.xml -->
-                  <appArgLine>-consolelog -debug -data target/workspace -application org.eclipse.ant.core.antRunner -quiet -buildfile buildDoc.xml -Dbasedir.properties=cbi_basedirs.properties -Declipse.javadoc=${eclipse.javadoc}</appArgLine>
+                  <applicationsArgs>
+		              <args>-consolelog</args>
+		              <args>-debug</args>
+		              <args>-data</args>
+		              <args>target/workspace</args>
+		              <args>-application</args>
+		              <args>org.eclipse.ant.core.antRunner</args>
+		              <args>-quiet</args>
+		              <args>-buildfile</args>
+		              <args>buildDoc.xml</args>
+		              <args>-Dbasedir.properties=cbi_basedirs.properties</args>
+		              <args>-Declipse.javadoc=${eclipse.javadoc}</args>
+                  </applicationsArgs>
                   <dependencies>
                     <!-- list of bundles that we need -->
                     <dependency>

--- a/bundles/org.eclipse.platform.doc.user/pom.xml
+++ b/bundles/org.eclipse.platform.doc.user/pom.xml
@@ -41,7 +41,16 @@
                 <phase>compile</phase>
                 <configuration>
                   <skip>false</skip>
-                  <appArgLine>-consolelog -debug -application org.eclipse.ant.core.antRunner -debug -buildfile customBuildCallbacks.xml build.index</appArgLine>
+                  <applicationsArgs>
+	                  <args>-consolelog</args>
+	                  <args>-debug</args>
+	                  <args>-application</args>
+	                  <args>org.eclipse.ant.core.antRunner</args>
+	                  <args>-debug</args>
+	                  <args>-buildfile</args>
+	                  <args>customBuildCallbacks.xml</args>
+	                  <args>build.index</args>
+                  </applicationsArgs>
                   <dependencies>
                     <dependency>
                       <artifactId>org.eclipse.osgi.compatibility.state</artifactId>


### PR DESCRIPTION
It's gone in 3.0.0-SNAPSHOT