### PR TITLE
Update the cbi_basedirs.properties to point to the new pde directory

### DIFF
--- a/bundles/org.eclipse.pde.doc.user/cbi_basedirs.properties
+++ b/bundles/org.eclipse.pde.doc.user/cbi_basedirs.properties
@@ -3,7 +3,7 @@ dependency.dir=target/dependency
 
 eclipse.pde.ui.apitools=../../../eclipse.pde/apitools
 eclipse.pde.ui.ui=../../../eclipse.pde/ui
-eclipse.pde.build=../../../eclipse.pde
+eclipse.pde.build=../../../eclipse.pde/build
 eclipse.jdt.core=../../../eclipse.jdt.core
 eclipse.jdt.debug=../../../eclipse.jdt.debug
 eclipse.jdt.ui=../../../eclipse.jdt.ui


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/228