### PR TITLE
Adjust path to eclipse.pde.build parent dir

### DIFF
--- a/bundles/org.eclipse.pde.doc.user/cbi_basedirs.properties
+++ b/bundles/org.eclipse.pde.doc.user/cbi_basedirs.properties
@@ -3,7 +3,7 @@ dependency.dir=target/dependency
 
 eclipse.pde.ui.apitools=../../../eclipse.pde/apitools
 eclipse.pde.ui.ui=../../../eclipse.pde/ui
-eclipse.pde.build=../../../eclipse.pde.build
+eclipse.pde.build=../../../eclipse.pde
 eclipse.jdt.core=../../../eclipse.jdt.core
 eclipse.jdt.debug=../../../eclipse.jdt.debug
 eclipse.jdt.ui=../../../eclipse.jdt.ui


### PR DESCRIPTION
It's merged into main pde repo. See
https://github.com/eclipse-pde/eclipse.pde/pull/39