### PR TITLE
List removal of org.eclipse.equinox.serverside.sdk in migration guide

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/porting/4.24/incompatibilities.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/4.24/incompatibilities.html
@@ -22,28 +22,28 @@ See also the list of <a href="../removals.html">deprecated API removals</a> for 
 
 
 <ol>
-<!--li><a href="#servlet-4-update">Update to Servlet 4</a></li-->
+<li><a href="#equinox-serverside-sdk-removal">Feature <code>org.eclipse.equinox.serverside.sdk</code> removed</a></li>
 </ol>
 
 <hr>
 
 <!-- ############################################## -->
 
-
-<!--h2>1. <a name="jetty-10-update">Update to Servlet 4</a></h2>
-<p><strong>What is affected:</strong> Clients that use <code>Servlet</code> APIs coming with Eclipse Platform.
+<h2>1. <a name="equinox-serverside-sdk-removal">Feature <code>org.eclipse.equinox.serverside.sdk</code> removed</a></h2>
+<p><strong>What is affected:</strong> Clients that use <code>org.eclipse.equinox.serverside.sdk</code> Feature coming with Eclipse Platform.
 </p>
 <p><strong>Description:</strong></p>
-Eclipse has updated to ship Servlet API to version 4 from previous version 3.
 <p>
-Bundle <code>javax.servlet</code> is renamed to <code>jakarta.servlet-api</code> to reflect the Servlet API being developed by JakartaEE project now. <br>
-Version 4.0 still keeps the <code>javax.servlet</code> package names as change to <code>jakarta.servlet</code> package names is not yet adopted by Eclipse.
+Eclipse has stopped to ship the Feature <code>org.eclipse.equinox.serverside.sdk</code>.
+</p>
+<p>
+All contained Features and Plug-ins remain available.
+Plug-ins that are not already contained in other features were added to the <code>org.eclipse.equinox.sdk</code> feature.
 </p>
 <p><strong>Action required:</strong></p>
 <ol>
-	<li>Adjust build scripts, target platform and etc. to use the new bundle symbolic name. </li>
-	<li>Implement and adjust to new Servlet 4.0 APIs</li>
-</ol-->
+	<li>Adjust build scripts, target platform and etc. to use the included Features or Plug-ins directly. </li>
+</ol
 
 </body>
 </html>


### PR DESCRIPTION
The feature `o.e.equinox.serverside.sdk` was removed with https://github.com/eclipse-equinox/equinox.bundles/pull/43.

This adds the corresponding Migration guide entry.