### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -98,7 +98,7 @@
 -splitIndex
 -windowtitle "Eclipse JDT API Specification"
 -doctitle "Eclipse JDT API Specification"
--header "<span style='font-size:small'><b>Eclipse JDT</b><br>2022-06 (4.24)</span>"
+-header "<span style='font-size:small'><b>Eclipse JDT</b><br>2022-09 (4.25)</span>"
 -bottom "<br><span style='font-size:small;float:right'>Copyright (c) 2000, 2022 Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>"
 -group "Java development tools core packages" "org.eclipse.jdt.core
 ;org.eclipse.jdt.core.*"

--- a/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jdt</groupId>

--- a/bundles/org.eclipse.jdt.doc.user/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jdt</groupId>

--- a/bundles/org.eclipse.jdt.tips.user/pom.xml
+++ b/bundles/org.eclipse.jdt.tips.user/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
+++ b/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
@@ -84,7 +84,7 @@
 
 -windowtitle "Eclipse PDE API Specification"
 -doctitle "Eclipse PDE API Specification"
--header "<span style='font-size:small'><b>Eclipse PDE</b><br>2022-06 (4.24)</span>"
+-header "<span style='font-size:small'><b>Eclipse PDE</b><br>2022-09 (4.25)</span>"
 -bottom "<br><span style='font-size:small;float:right'>Copyright (c) 2000, 2022 Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>"
 -link https://docs.oracle.com/en/java/javase/17/docs/api
 -link https://docs.osgi.org/javadoc/osgi.core/8.0.0/

--- a/bundles/org.eclipse.pde.doc.user/pom.xml
+++ b/bundles/org.eclipse.pde.doc.user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.pde</groupId>

--- a/bundles/org.eclipse.platform.doc.isv/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.platform.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform.doc.isv; singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -188,7 +188,7 @@
 -splitIndex
 -windowtitle "Eclipse Platform API Specification"
 -doctitle "Eclipse Platform API Specification"
--header "<span style='font-size:small'><b>Eclipse Platform</b><br>2022-06 (4.24)</span>"
+-header "<span style='font-size:small'><b>Eclipse Platform</b><br>2022-09 (4.25)</span>"
 -bottom "<br><span style='font-size:small;float:right'>Copyright (c) 2000, 2022 Eclipse Contributors and others. All rights reserved.</span><span style='font-size:small'><a href='{@docRoot}/../misc/api-usage-rules.html'>Guidelines for using Eclipse APIs.</a></span>"
 -link https://docs.oracle.com/en/java/javase/17/docs/api
 -link https://docs.osgi.org/javadoc/osgi.core/8.0.0/

--- a/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform</groupId>

--- a/bundles/org.eclipse.platform.doc.tips/pom.xml
+++ b/bundles/org.eclipse.platform.doc.tips/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/bundles/org.eclipse.platform.doc.user/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.platform.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.platform.doc.user; singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/bundles/org.eclipse.platform.doc.user/pom.xml
+++ b/bundles/org.eclipse.platform.doc.user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.common</artifactId>
     <groupId>eclipse.platform.common</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release