### PR TITLE
Use Eclipse Platform User Guide instead of Workbench User Guide

### DIFF
--- a/bundles/org.eclipse.jdt.doc.user/gettingStarted/qs-2.htm
+++ b/bundles/org.eclipse.jdt.doc.user/gettingStarted/qs-2.htm
@@ -30,7 +30,7 @@
     </ul>
     <p>
       If you're not familiar with the basic workbench mechanisms, please see the
-      <a href="PLUGINS_ROOT/org.eclipse.platform.doc.user/gettingStarted/qs-01.htm">Getting Started</a> chapter of the Workbench User Guide.
+      <a href="PLUGINS_ROOT/org.eclipse.platform.doc.user/gettingStarted/qs-01.htm">Getting Started</a> chapter of the Eclipse Platform User Guide.
     </p>
     <h2>
       Verifying JRE installation and classpath variables

--- a/bundles/org.eclipse.platform.doc.isv/whatsNew/platform_isv_whatsnew.html
+++ b/bundles/org.eclipse.platform.doc.isv/whatsNew/platform_isv_whatsnew.html
@@ -34,7 +34,7 @@ made to the Eclipse Platform and SWT for the 4.24 release of Eclipse.
 New features oriented towards end-users of the platform
 can be viewed in the
 <a href="../../org.eclipse.platform.doc.user/whatsNew/platform_whatsnew.html">What's New</a>
-section of the Workbench User Guide.
+section of the Eclipse Platform User Guide.
 </p>
 
 <!-- ****************** START OF N&N TABLE****************** -->

--- a/bundles/org.eclipse.platform.doc.user/plugin.properties
+++ b/bundles/org.eclipse.platform.doc.user/plugin.properties
@@ -8,5 +8,5 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-pluginName=Eclipse Workbench User Guide
+pluginName=Eclipse Platform User Guide
 providerName=Eclipse.org

--- a/bundles/org.eclipse.platform.doc.user/reference/ref-43.htm
+++ b/bundles/org.eclipse.platform.doc.user/reference/ref-43.htm
@@ -6,13 +6,13 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta http-equiv="Content-Style-Type" content="text/css">
   <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-  <title>Workbench User Guide</title>
+  <title>Eclipse Platform User Guide</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Workbench User Guide</h1>
-  <p class="Para">The Help view displays help related to using the Workbench. If you select Workbench User Guide in the
+  <h1 class="Head">Eclipse Platform User Guide</h1>
+  <p class="Para">The Help view displays help related to using the Workbench. If you select Eclipse Platform User Guide in the
   list of books displayed in the Help window, you will see help topics related to using the Workbench in the Contents
-  tab. The Workbench User Guide is broken down into four main sections, described below.</p>
+  tab. The Eclipse Platform User Guide is broken down into four main sections, described below.</p>
   <div class="Topic">
     <div class="Subtopic">
       <h2 class="Head">Getting started</h2>

--- a/bundles/org.eclipse.platform.doc.user/toc.xml
+++ b/bundles/org.eclipse.platform.doc.user/toc.xml
@@ -4,7 +4,7 @@
 <!-- Define the top level topics                                                   -->
 <!-- ============================================================================= -->
 
-<toc label="Workbench User Guide">
+<toc label="Eclipse Platform User Guide">
    <topic label="Eclipse platform overview" href="gettingStarted/intro/overview.htm"/>
 	<topic label="Getting started">
 		<link toc="topics_GettingStarted.xml" />

--- a/bundles/org.eclipse.platform.doc.user/topics_Reference.xml
+++ b/bundles/org.eclipse.platform.doc.user/topics_Reference.xml
@@ -207,7 +207,7 @@
 
 
 	<topic label="Help contents">
-		<topic label="Workbench User Guide" href="reference/ref-43.htm"></topic>
+		<topic label="Eclipse Platform User Guide" href="reference/ref-43.htm"></topic>
 		<topic label="Working with cheat sheets" href="reference/ref-cheatsheets.htm">
 		    <topic label="Working with composite cheat sheets" href="reference/ref-composite-cheatsheets.htm"></topic>
 			<enablement>


### PR DESCRIPTION
The * User Guide is the first help topic we are displaying and using a
technical term as chapter is not intuitive for new users. Also the first
section under the User Guide is "Eclipse Platform overview" so it is
more consistent to also name the title so.