### PR TITLE
Add org.osgi.service event and cm jars to javadoc-build classpath

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -38,6 +38,8 @@
 ;${dependency.dir}/${org.junit.jar}
 ;${dependency.dir}/com.ibm.icu_*.jar
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
+;${dependency.dir}/org.osgi.service.event_*.jar
+;${dependency.dir}/org.osgi.service.cm_*.jar
 ;${eclipse.equinox.supplement}/${dot.classes}
 ;${eclipse.jdt.core}/org.eclipse.jdt.apt.core/mirrorapi.jar
 ;${eclipse.jdt.debug}/org.eclipse.jdt.debug/jdi.jar

--- a/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
+++ b/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
@@ -10,6 +10,8 @@
 -classpath @rt@
 ;${dependency.dir}/com.ibm.icu_*.jar
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
+;${dependency.dir}/org.osgi.service.event_*.jar
+;${dependency.dir}/org.osgi.service.cm_*.jar
 ;${eclipse.equinox.supplement}/${dot.classes}
 ;${eclipse.jdt.core}/org.eclipse.jdt.core/${dot.classes}
 ;${eclipse.jdt.debug}/org.eclipse.jdt.debug/jdi.jar

--- a/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -159,6 +159,8 @@
 ;${dependency.dir}/org.eclipse.emf.ecore.xmi_*.jar
 ;${dependency.dir}/org.eclipse.emf.ecore_*.jar
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
+;${dependency.dir}/org.osgi.service.event_*.jar
+;${dependency.dir}/org.osgi.service.cm_*.jar
 ;${dependency.dir}/jetty-http_*.jar
 ;${dependency.dir}/jetty-io_*.jar
 ;${dependency.dir}/jetty-security_*.jar


### PR DESCRIPTION
This is intended to fix the java-doc build that currently fails (mentioned in https://github.com/eclipse-equinox/equinox/issues/18#issuecomment-1159639767):
https://download.eclipse.org/eclipse/downloads/drops4/I20220618-1800/compilelogs/platform.doc.isv.javadoc.txt

Based on https://github.com/eclipse-platform/eclipse.platform.common/pull/19 just the jars of the missing packages are added.

Is there a quick way to test if this works or will we just see with the next I-build?