### PR TITLE
Move planned PDE removals to new remove section after removal

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -94,6 +94,14 @@ Removed APIs in the Eclipse 4.24 release:
  
 </ol>
 
+<p>
+Removed APIs in the Eclipse 4.25 release:
+</p>
+<ol>
+ <li><a href="#pde.ui.launcher">Remove deprecated contents of org.eclipse.pde.ui.launcher package</a></li>
+ <li><a href="#createPlatformConfiguration">Remove TargetPlatform::createPlatformConfiguration</a></li>
+</ol>
+
 
 <h2>Overview of planned API removals</h2>
 
@@ -149,14 +157,6 @@ Planned API removals after June 2022:
 </p>
 <ol>
  <li><a href="#icu4j">ICU4J bundle from SDK</a></li>
-</ol>
-
-<p>
-Planned API removals after September 2022:
-</p>
-<ol>
- <li><a href="#pde.ui.launcher">Remove deprecated contents of org.eclipse.pde.ui.launcher package</a></li>
- <li><a href="#createPlatformConfiguration">Remove TargetPlatform::createPlatformConfiguration</a></li>
 </ol>
 
 <p>


### PR DESCRIPTION
Reflect the final removal of PDE API's which was planned since the usual two years:
- https://github.com/eclipse-pde/eclipse.pde/pull/182
- https://github.com/eclipse-pde/eclipse.pde/pull/198

