### PR TITLE
Add help stubs for 4.25

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/porting/4.25/faq.html
+++ b/bundles/org.eclipse.jdt.doc.isv/porting/4.25/faq.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse JDT 4.25 Plug-in Migration FAQ</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.25 Plug-in Migration FAQ</h1>
+
+<ol>
+	<li>None</li>
+</ol>
+
+</body>
+</html>

--- a/bundles/org.eclipse.jdt.doc.isv/porting/4.25/incompatibilities.html
+++ b/bundles/org.eclipse.jdt.doc.isv/porting/4.25/incompatibilities.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Incompatibilities between Eclipse JDT 4.24 and 4.25</title>
+</head>
+<body>
+<h1>Incompatibilities between Eclipse JDT 4.24 and 4.25</h1>
+
+<p>
+  So far Eclipse did not change incompatibly between 4.24 and 4.25 in ways that affect
+  plug-ins. Plug-ins that ran on 4.24 should run on 4.25 without any problems.
+</p>
+
+</body>
+</html>

--- a/bundles/org.eclipse.jdt.doc.isv/porting/4.25/recommended.html
+++ b/bundles/org.eclipse.jdt.doc.isv/porting/4.25/recommended.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Adopting JDT 4.25 mechanisms and APIs</title>
+</head>
+
+<body>
+
+<h1>Adopting JDT 4.25 mechanisms and APIs</h1>
+<p>
+  This section describes changes that are required if you are trying to change
+  your 4.24 plug-in to adopt the 4.25 mechanisms and APIs.
+</p>
+
+<ol>
+	<li>None</li>
+</ol>
+</body>
+</html>

--- a/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_25_porting_guide.html
+++ b/bundles/org.eclipse.jdt.doc.isv/porting/eclipse_4_25_porting_guide.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+
+<head>
+
+<meta name="copyright" content="Copyright (c) IBM 2022 Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse JDT 4.25 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse JDT 4.25 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse JDT 4.24 plug-ins to Eclipse JDT 4.25.</p>
+<p>One of the goals of Eclipse 4.25 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.24 APIs should continue to work in 4.25 in spite of the
+  API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.24 APIs remains valid for
+  4.25, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.25 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.24 plug-ins to
+  4.25.</p>
+<ul>
+  <li><a href="4.25/faq.html">Eclipse JDT 4.25 Plug-in Migration FAQ</a></li>
+  <li><a href="4.25/incompatibilities.html">Incompatibilities between Eclipse JDT 4.24 and 4.25</a></li>
+  <li><a href="4.25/recommended.html">Adopting 4.25 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/topics_Porting.xml
@@ -4,6 +4,12 @@
 <!-- Define topics for the porting guide index                                     -->
 <!-- ============================================================================= -->
 <toc label="Migration">
+	<topic label="Migrating to Eclipse JDT 4.25 from 4.24">
+		<topic label="Introduction" href="porting/eclipse_4_24_porting_guide.html"/>
+		<topic label="FAQ"                             href="porting/4.25/faq.html" />
+		<topic label="Incompatibilities"               href="porting/4.25/incompatibilities.html" />
+		<topic label="Adopting 4.25 Mechanisms and API" href="porting/4.25/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse JDT 4.24 from 4.23">
 		<topic label="Introduction" href="porting/eclipse_4_24_porting_guide.html"/>
 		<topic label="FAQ"                             href="porting/4.24/faq.html" />

--- a/bundles/org.eclipse.platform.doc.isv/porting/4.25/faq.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/4.25/faq.html
@@ -1,0 +1,27 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.25 Plug-in Migration FAQ</title>
+</head>
+<body>
+<h1>Eclipse 4.25 Plug-in Migration FAQ</h1>
+
+<!--ol>
+	<li><a href="#project-layout">How can I force a Flat project layout in the <i>Project Explorer</i> view?</a></li>
+</ol-->
+
+<hr>
+
+<!-- ############################################## -->
+<!--h2><a name="project-layout">1. How can I force a Flat project layout in the <i>Project Explorer</i> view?</a></h2>
+<p>As default Project Layout in Project Explorer has been switched to hierarchical, a new preference is available for RCP providers who want to force Flat layout by default instead. The preference is
+<code>org.eclipse.ui.navigator.resources/defaultToFlatLayout</code> and can be set to <code>true</code> in <code>plugin_customization.ini</code> or programatically <i>before</i> Project Explorer opens
+for the first time, in order to force a Flat project layout. Subsequent change to this preference after first initialization of Project Explorer will have no effect.</p-->
+<!-- ############################################## -->
+
+</body>
+</html>

--- a/bundles/org.eclipse.platform.doc.isv/porting/4.25/incompatibilities.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/4.25/incompatibilities.html
@@ -5,16 +5,16 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta http-equiv="Content-Style-Type" content="text/css">
 <link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1" type="text/css">
-<title>Incompatibilities between Eclipse 4.23 and 4.24</title>
+<title>Incompatibilities between Eclipse 4.24 and 4.25</title>
 </head>
 <body>
-<h1>Incompatibilities between Eclipse 4.23 and 4.24</h1>
+<h1>Incompatibilities between Eclipse 4.24 and 4.25</h1>
 
 <p>
-  Eclipse changed in incompatible ways between 4.23 and 4.24 in ways that affect
+  Eclipse changed in incompatible ways between 4.24 and 4.25 in ways that affect
   plug-ins. The following entries describe the areas that changed and provide
-  instructions for migrating 4.23 plug-ins to 4.24. Note that you only need to look
-  here if you are experiencing problems running your 4.23 plug-in on 4.24.
+  instructions for migrating 4.24 plug-ins to 4.25. Note that you only need to look
+  here if you are experiencing problems running your 4.24 plug-in on 4.25.
 </p>
 <p>
 See also the list of <a href="../removals.html">deprecated API removals</a> for this release.
@@ -22,14 +22,14 @@ See also the list of <a href="../removals.html">deprecated API removals</a> for 
 
 
 <ol>
-<li><a href="#equinox-serverside-sdk-removal">Feature <code>org.eclipse.equinox.serverside.sdk</code> removed</a></li>
+<!--li><a href="#equinox-serverside-sdk-removal">Feature <code>org.eclipse.equinox.serverside.sdk</code> removed</a></li-->
 </ol>
 
 <hr>
 
 <!-- ############################################## -->
 
-<h2>1. <a name="equinox-serverside-sdk-removal">Feature <code>org.eclipse.equinox.serverside.sdk</code> removed</a></h2>
+<!--h2>1. <a name="equinox-serverside-sdk-removal">Feature <code>org.eclipse.equinox.serverside.sdk</code> removed</a></!--h2>
 <p><strong>What is affected:</strong> Clients that use <code>org.eclipse.equinox.serverside.sdk</code> Feature coming with Eclipse Platform.
 </p>
 <p><strong>Description:</strong></p>
@@ -43,7 +43,7 @@ Plug-ins that are not already contained in other features were added to the <cod
 <p><strong>Action required:</strong></p>
 <ol>
 	<li>Adjust build scripts, target platform and etc. to use the included Features or Plug-ins directly. </li>
-</ol>
+</ol-->
 
 </body>
 </html>

--- a/bundles/org.eclipse.platform.doc.isv/porting/4.25/recommended.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/4.25/recommended.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright"
+	content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../../book.css" charset="ISO-8859-1"
+	type="text/css">
+<title>Adopting 4.25 mechanisms and APIs</title>
+</head>
+<body>
+	<h1>Adopting 4.25 mechanisms and APIs</h1>
+
+	<p>This section describes changes that are required if you are
+		trying to change your 4.23 plug-in to adopt the 4.25 mechanisms and
+		APIs.</p>
+
+	<ol>
+		<!--li><a href="#pack200Removal">Pack200 artifacts will no longer be generated for Eclipse starting with 4.22 release</a></li-->
+	</ol>
+
+	<hr>
+
+	<!-- ############################################## -->
+	<!--h2>
+		1. <a name="pack200Removal">Pack200 artifacts will no longer be generated starting with 4.22 release</a>
+	</h2>
+	<p>
+		<strong>What is affected:</strong> Clients relying on availability of pack200 artifacts (*.pack.gz) in Eclipse Platform p2 repository.
+	</p>
+	<p>
+		<strong>Description:</strong> Clients using pack200 (*.pack.gz) artifacts from Eclipse Platform p2 repository are advised to stop doing so and
+		rely on plain old *.jar files instead.
+	</p>
+	<p>
+		<strong>Action required:</strong> If your build system/scripts have strong requirement on existence of *.pack.gz artifacts for Eclipse Platform bits
+		do the needed modifications so it can work when these are not around prior to starting to build against 4.22 release.
+		
+	</p-->
+	
+</body>
+</html>

--- a/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) 2022 IBM Corporation and others. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 4.25 Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse 4.25 Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse 4.24 plug-ins to Eclipse 4.25.</p>
+<p>One of the goals of Eclipse 4.25 was to move Eclipse forward while remaining compatible
+  with previous versions to the greatest extent possible. That is, plug-ins written
+  against the Eclipse 4.24 APIs should continue to work in 4.25 in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility.
+  API contract compatibility means that valid use of 4.24 APIs remains valid for
+  4.25, so there is no need to revisit working code. Binary compatibility means
+  that the API method signatures, etc. did not change in ways that would cause
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the
+  new 4.25 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients.
+  This document describes those areas and provides instructions for migrating 4.24 plug-ins to
+  4.25.</p>
+<ul>
+  <li><a href="4.25/faq.html">Eclipse 4.25 Plug-in Migration FAQ</a></li>
+  <li><a href="4.25/incompatibilities.html">Incompatibilities between Eclipse 4.24 and 4.25</a></li>
+  <li><a href="4.25/recommended.html">Adopting 4.25 mechanisms and API</a></li>
+</ul>
+
+</body>
+</html>

--- a/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
+++ b/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
@@ -5,6 +5,12 @@
 <!-- ============================================================================= -->
 <toc label="Migration">
 	<topic label="Deprecated API removals" href="porting/removals.html"/>
+	<topic label="Migrating to Eclipse 4.25 from 4.24">
+		<topic label="Introduction" href="porting/eclipse_4_24_porting_guide.html"/>
+		<topic label="FAQ" href="porting/4.25/faq.html" />
+		<topic label="Incompatibilities" href="porting/4.25/incompatibilities.html" />
+		<topic label="Adopting 4.25 mechanisms and API" href="porting/4.25/recommended.html" />
+	</topic>
 	<topic label="Migrating to Eclipse 4.24 from 4.23">
 		<topic label="Introduction" href="porting/eclipse_4_24_porting_guide.html"/>
 		<topic label="FAQ" href="porting/4.24/faq.html" />


### PR DESCRIPTION
Create help stubs for 4.25.
I thought this was necessary to reflect the final PDE API removal done in #43. It wasn't, but since I had already done it: here it is.

Can somebody check if this is correct? Basically I copied the folders/files for 4.24 and replaced `4.24` by `4.25` and `4.23` by `4.24` and commented out the previous entry in the `/org.eclipse.platform.doc.isv/4.24/incompatibilities.html`.