### PR TITLE
Javadoc generation use Maven artifactId

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -36,7 +36,7 @@
 -classpath @rt@
 ;${dependency.dir}/${org.apache.ant.jar}
 ;${dependency.dir}/${org.junit.jar}
-;${dependency.dir}/com.ibm.icu_*.jar
+;${dependency.dir}/icu4j_*.jar
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
 ;${dependency.dir}/org.osgi.service.event_*.jar
 ;${dependency.dir}/org.osgi.service.cm_*.jar

--- a/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -133,7 +133,7 @@
 ;${rt.equinox.p2.bundles}/org.eclipse.equinox.p2.ui/src
 -d reference/api
 -classpath @rt@
-;${dependency.dir}/com.ibm.icu_*.jar
+;${dependency.dir}/icu4j_*.jar
 ;${dependency.dir}/com.jcraft.jsch_*.jar
 ;${dependency.dir}/javax.annotation_*.jar
 ;${dependency.dir}/javax.el_*.jar


### PR DESCRIPTION
Because maven-dependency-plugin is used.
So replace com.ibm.icu by icu4j when referencing it for Javadoc
generation