### PR TITLE
Fix Javadoc classpath computation

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/buildDoc.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/buildDoc.xml
@@ -112,9 +112,11 @@
 			<!-- strip away leading path -->
 		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^.*/([^/]*)$$" replace="\1" />
 			<!-- remove lines without version pattern "[_-]\d+\.\d+\.\d+"; version pattern is a workaround for bug 402392 -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.\d+.*)|(.*)$$" replace="\1" />
+			<!-- updated to \d+\.\d+\.?\d*.* regexp to capture version for eg icu-67.1 -->
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.?\d*.*)|(.*)$$" replace="\1" />
 			<!-- create "<aa>_*[.jar]=<aa><version>[.jar]" property for lines with a version -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.\d+.*?(.jar)?$$" replace="\1_*\2=\0" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.?\d*.*(.jar)?$$" replace="\1_*\2=\0" />
+
 
 <!--
 <echo>${basedir}/${replaceFile} after _* expansion:</echo>

--- a/bundles/org.eclipse.pde.doc.user/buildDoc.xml
+++ b/bundles/org.eclipse.pde.doc.user/buildDoc.xml
@@ -112,9 +112,10 @@
 			<!-- strip away leading path -->
 		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^.*/([^/]*)$$" replace="\1" />
 			<!-- remove lines without version pattern "[_-]\d+\.\d+\.\d+"; version pattern is a workaround for bug 402392 -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.\d+.*)|(.*)$$" replace="\1" />
+			<!-- updated to \d+\.\d+\.?\d*.* regexp to capture version for eg icu-67.1 -->
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.?\d*.*)|(.*)$$" replace="\1" />
 			<!-- create "<aa>_*[.jar]=<aa><version>[.jar]" property for lines with a version -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.\d+.*?(.jar)?$$" replace="\1_*\2=\0" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.?\d*.*(.jar)?$$" replace="\1_*\2=\0" />
 
 <!--
 <echo>${basedir}/${replaceFile} after _* expansion:</echo>

--- a/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
+++ b/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
@@ -8,7 +8,7 @@
 ;${eclipse.pde.ui.ui}/org.eclipse.pde.ui/src"
 -d reference/api
 -classpath @rt@
-;${dependency.dir}/com.ibm.icu_*.jar
+;${dependency.dir}/icu4j_*.jar
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
 ;${dependency.dir}/org.osgi.service.event_*.jar
 ;${dependency.dir}/org.osgi.service.cm_*.jar

--- a/bundles/org.eclipse.platform.doc.isv/buildDoc.xml
+++ b/bundles/org.eclipse.platform.doc.isv/buildDoc.xml
@@ -181,9 +181,10 @@
 			<!-- strip away leading path -->
 		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^.*/([^/]*)$$" replace="\1" />
 			<!-- remove lines without version pattern "[_-]\d+\.\d+\.\d+"; version pattern is a workaround for bug 402392 -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.\d+.*)|(.*)$$" replace="\1" />
+			<!-- updated to \d+\.\d+\.?\d*.* regexp to capture version for eg icu-67.1 -->
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.?\d*.*)|(.*)$$" replace="\1" />
 			<!-- create "<aa>_*[.jar]=<aa><version>[.jar]" property for lines with a version -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.\d+.*?(.jar)?$$" replace="\1_*\2=\0" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.?\d*.*(.jar)?$$" replace="\1_*\2=\0" />
 
 <!--
 <echo>${basedir}/${replaceFile} after _* expansion:</echo>


### PR DESCRIPTION
All jars with version being 2 segments were removed from javadoc
classpath. Fix the regexp so those ones are properly handled.