### PR TITLE
Revert "Fix Javadoc classpath computation"

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/buildDoc.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/buildDoc.xml
@@ -112,11 +112,9 @@
 			<!-- strip away leading path -->
 		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^.*/([^/]*)$$" replace="\1" />
 			<!-- remove lines without version pattern "[_-]\d+\.\d+\.\d+"; version pattern is a workaround for bug 402392 -->
-			<!-- updated to \d+\.\d+\.?\d*.* regexp to capture version for eg icu-67.1 -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.?\d*.*)|(.*)$$" replace="\1" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.\d+.*)|(.*)$$" replace="\1" />
 			<!-- create "<aa>_*[.jar]=<aa><version>[.jar]" property for lines with a version -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.?\d*.*(.jar)?$$" replace="\1_*\2=\0" />
-
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.\d+.*?(.jar)?$$" replace="\1_*\2=\0" />
 
 <!--
 <echo>${basedir}/${replaceFile} after _* expansion:</echo>

--- a/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -139,6 +139,10 @@
                       <artifactId>org.eclipse.update.configurator</artifactId>
                       <type>eclipse-plugin</type>
                     </dependency>
+                    <dependency>
+                      <type>eclipse-plugin</type>
+                      <artifactId>com.ibm.icu</artifactId>
+                    </dependency>
                   </dependencies>
                 </configuration>
                 <goals>

--- a/bundles/org.eclipse.pde.doc.user/buildDoc.xml
+++ b/bundles/org.eclipse.pde.doc.user/buildDoc.xml
@@ -112,10 +112,9 @@
 			<!-- strip away leading path -->
 		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^.*/([^/]*)$$" replace="\1" />
 			<!-- remove lines without version pattern "[_-]\d+\.\d+\.\d+"; version pattern is a workaround for bug 402392 -->
-			<!-- updated to \d+\.\d+\.?\d*.* regexp to capture version for eg icu-67.1 -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.?\d*.*)|(.*)$$" replace="\1" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.\d+.*)|(.*)$$" replace="\1" />
 			<!-- create "<aa>_*[.jar]=<aa><version>[.jar]" property for lines with a version -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.?\d*.*(.jar)?$$" replace="\1_*\2=\0" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.\d+.*?(.jar)?$$" replace="\1_*\2=\0" />
 
 <!--
 <echo>${basedir}/${replaceFile} after _* expansion:</echo>

--- a/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
+++ b/bundles/org.eclipse.pde.doc.user/pdeOptions.txt
@@ -8,7 +8,7 @@
 ;${eclipse.pde.ui.ui}/org.eclipse.pde.ui/src"
 -d reference/api
 -classpath @rt@
-;${dependency.dir}/icu4j_*.jar
+;${dependency.dir}/com.ibm.icu_*.jar
 ;${dependency.dir}/org.osgi.service.prefs_*.jar
 ;${dependency.dir}/org.osgi.service.event_*.jar
 ;${dependency.dir}/org.osgi.service.cm_*.jar

--- a/bundles/org.eclipse.pde.doc.user/pom.xml
+++ b/bundles/org.eclipse.pde.doc.user/pom.xml
@@ -138,6 +138,10 @@
                       <artifactId>org.eclipse.update.configurator</artifactId>
                       <type>eclipse-plugin</type>
                     </dependency>
+                    <dependency>
+                      <type>eclipse-plugin</type>
+                      <artifactId>com.ibm.icu</artifactId>
+                    </dependency>
                   </dependencies>
                 </configuration>
                 <goals>

--- a/bundles/org.eclipse.platform.doc.isv/buildDoc.xml
+++ b/bundles/org.eclipse.platform.doc.isv/buildDoc.xml
@@ -181,10 +181,9 @@
 			<!-- strip away leading path -->
 		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^.*/([^/]*)$$" replace="\1" />
 			<!-- remove lines without version pattern "[_-]\d+\.\d+\.\d+"; version pattern is a workaround for bug 402392 -->
-			<!-- updated to \d+\.\d+\.?\d*.* regexp to capture version for eg icu-67.1 -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.?\d*.*)|(.*)$$" replace="\1" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*[-_]\d+\.\d+\.\d+.*)|(.*)$$" replace="\1" />
 			<!-- create "<aa>_*[.jar]=<aa><version>[.jar]" property for lines with a version -->
-		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.?\d*.*(.jar)?$$" replace="\1_*\2=\0" />
+		<replaceregexp file="${basedir}/${replaceFile}" flags="g" match="(?m)^(.*)[-_]\d+\.\d+\.\d+.*?(.jar)?$$" replace="\1_*\2=\0" />
 
 <!--
 <echo>${basedir}/${replaceFile} after _* expansion:</echo>

--- a/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -327,6 +327,10 @@
                       <type>eclipse-plugin</type>
                       <artifactId>org.bouncycastle.bcprov</artifactId>
                     </dependency>
+                    <dependency>
+                      <type>eclipse-plugin</type>
+                      <artifactId>com.ibm.icu</artifactId>
+                    </dependency>
                   </dependencies>
                 </configuration>
                 <goals>


### PR DESCRIPTION
This reverts commit ddab1222000033b3de96189f8e6eca0306121559.
Instead of tweaking Ant regex (tricky), we just add the necessary bundle
to boot classpath so it doesn't have to be further mapped in
*Options.txt
files