### PR TITLE
Fix bcpg artifact name

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -170,8 +170,8 @@
 ;${dependency.dir}/org.sat4j.core_*.jar
 ;${dependency.dir}/org.sat4j.pb_*.jar
 ;${dependency.dir}/org.w3c.css.sac_*.jar
-;${dependency.dir}/bcpg_*.jar
-;${dependency.dir}/bcprov_*.jar
+;${dependency.dir}/bcpg-jdk18on_*.jar
+;${dependency.dir}/bcprov-jdk18on_*.jar
 ;${eclipse.equinox.supplement}/${dot.classes}
 ;${eclipse.platform.ua}/org.eclipse.help.appserver/${dot.classes}
 ;${eclipse.platform.ui.bundles}/org.eclipse.e4.ui.workbench.addons.swt/${dot.classes}


### PR DESCRIPTION
platformOptions requires jarname (Maven artifactId), not the
bundle-symbolicname