### PR TITLE
Update cbi_basedirs.properties to the new team repo for Javadoc build

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/cbi_basedirs.properties
+++ b/bundles/org.eclipse.platform.doc.isv/cbi_basedirs.properties
@@ -9,7 +9,7 @@ eclipse.platform.platform=../../../eclipse.platform/platform
 eclipse.platform.resources.bundles=../../../eclipse.platform.resources/bundles
 eclipse.platform.runtime.bundles=../../../eclipse.platform/runtime/bundles
 eclipse.platform.swt.bundles=../../../eclipse.platform.swt/bundles
-eclipse.platform.team.bundles=../../../eclipse.platform.team/bundles
+eclipse.platform.team.bundles=../../../eclipse.platform/team/bundles
 eclipse.platform.text=../../../eclipse.platform.text
 eclipse.platform.ua=../../../eclipse.platform.ua
 eclipse.platform.ui.bundles=../../../eclipse.platform.ui/bundles
@@ -17,7 +17,7 @@ eclipse.platform.update=../../../eclipse.platform/update
 rt.equinox.bundles.bundles=../../../equinox/bundles
 rt.equinox.framework.bundles=../../../equinox/bundles
 rt.equinox.p2.bundles=../../../rt.equinox.p2/bundles
-eclipse.platform.team.examples=../../../eclipse.platform.team/examples
+eclipse.platform.team.examples=../../../eclipse.platform/team/examples
 eclipse.platform.swt.examples=../../../eclipse.platform.swt/examples
 eclipse.platform.ui.examples=../../../eclipse.platform.ui/examples
 


### PR DESCRIPTION
As team is now merged into the eclipse.platform repo, we need to updates
its path.