### PR TITLE
Simplify the API removals document

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -8,399 +8,29 @@
 <title>Deprecated API removals</title>
 </head>
 <body>
-<h1>Deprecated API removals</h1>
+
+<h2>Overview</h2>
+
+<p>
+
+</p>
+<ol>
+ <li><a href="#planned">Planned API removals</a></li>
+</ol>
+<p>
+</p>
+<ol>
+ <li><a href="#removed">Removed API</a></li>
+</ol>
+
+
+<h1 id="planned">Planned Deprecated API removals</h1>
 
 <p>
   Deprecated API can be marked for deletion.
   See the <a href="http://wiki.eclipse.org/Eclipse/API_Central/Deprecation_Policy">policy</a> for the details.
   This section describes API removals that occurred in past releases, and upcoming removals in future releases.
 </p>
-
-
-<h2>Overview of removed API</h2>
-
-<p>
-Removed APIs in the Neon (4.6) release:
-</p>
-<ol>
- <li><a href="#runtime">Eclipse 2.0 runtime model and boot API</a></li>
-</ol>
-<p>
-Removed APIs in the Oxygen (4.7) release:
-</p>
-<ol>
- <li><a href="#listenerlist">org.eclipse.jface.util.ListenerList</a></li>
-</ol>
-
-<p>
-Removed APIs in the Photon (4.8) release:
-</p>
-<ol>
- <li><a href="#updatemanager">Update manager</a></li>
- <li><a href="#platform-methods">Platform methods</a></li>
- <li><a href="#tasklist">org.eclipse.ui.views.tasklist.TaskList</a></li>
-  <li><a href="#icontextcomputer">IContextComputer</a></li>
-</ol>
-
-<p>
-Removed APIs in the Eclipse 4.10 release:
-</p>
-<ol>
- <li><a href="#tabletreeviewer">TableTree and TableTreeViewer</a></li>
-</ol>
-
-
-<p>
-Removed APIs in the Eclipse 4.11 release:
-</p>
-<ol>
- <li><a href="#imageandmessagearea">ImageAndMessageArea from JFace</a></li>
-</ol>
-
-<p>
-Removed APIs in the Eclipse 4.12 release:
-</p>
-<ol>
- <li><a href="#iplugindescriptor">IPluginDescriptor</a></li>
- <li><a href="#tabletree">TableTree</a></li>
-</ol>
-
-<p>
-Removed APIs in the Eclipse 4.17 release:
-</p>
-<ol>
- <li><a href="#minputpart">Remove Input and MInputPart</a></li>
- <li><a href="#platform-getjobmanager">org.eclipse.core.runtime.Platform#getJobManager()</a></li>
-  <li><a href="#jfaceassert">JFace and JFace text Assert</a></li>
-</ol>
-
-<p>
-Removed APIs in the Eclipse 4.20 release:
-</p>
-<ol>
- <li><a href="#jobcreateSystem">Delete Job.createSystem(ICoreRunnable) API </a></li>
- <li><a href="#iplatformrunnable">Remove org.eclipse.core.runtime.IPlatformRunnable</a></li>
- <li><a href="#targetProvisioners">Remove org.eclipse.pde.ui.targetProvisioners extension point</a></li>
-  <li><a href="#20supportclasses">Delete 2.0 plug-in compatibility classes and related API</a></li>
-</ol>
-
-<p>
-Removed APIs in the Eclipse 4.24 release:
-</p>
-<ol>
- <li><a href="#bookmark">Bookmark view and related API</a></li>
- <li><a href="#auth">Platform authorization API</a></li>
- <li><a href="#workbenchwindowconfigurer">Delete unsupported methods in WorkbenchWindowConfigurer </a></li>
- 
-</ol>
-
-<p>
-Removed APIs in the Eclipse 4.25 release:
-</p>
-<ol>
- <li><a href="#pde.ui.launcher">Remove deprecated contents of org.eclipse.pde.ui.launcher package</a></li>
- <li><a href="#createPlatformConfiguration">Remove TargetPlatform::createPlatformConfiguration</a></li>
-</ol>
-
-
-<h2>Overview of planned API removals</h2>
-
-
-<p>
-Planned API removals after June 2018:
-</p>
-<ol>
- <li><a href="#fullscreen">org.eclipse.ui.cocoa.fullscreenWindow</a></li>
-</ol>
-
-<p>
-Planned API removals after June 2020:
-</p>
-<ol>
- <li><a href="#mpartdescriptor">Remove Dirtable flag from MPartDescriptor</a></li>
- <li><a href="#ui-dialogs">Remove deprecated dialogs from org.eclipse.ui.dialogs</a></li>
- <li><a href="#jface-popupdialog">Remove deprecated method and constructor in PopupDialog</a></li>
-</ol>
-
-<p>
-Planned API removals after March 2021:
-</p>
-<ol>
- <li><a href="#commandsutil">org.eclipse.core.commands.util package</a></li>
- <li><a href="#encodingactiongroup">org.eclipse.ui.editors.text.EncodingActionGroup</a></li>
- <li><a href="#equinoxlauncher">org.eclipse.core.launcher#Main and WebStartMain</a></li>
-</ol>
-
-<p>
-Planned API removals after June 2021:
-</p>
-<ol>
- <li><a href="#commands">Delete deprecated contents of org.eclipse.ui.commands package</a></li>
-</ol>
-
-<p>
-Planned API removals after September 2021:
-</p>
-<ol>
- <li><a href="#navigator">Navigator view and related API</a></li>
-</ol>
-
-<p>
-Planned API removals after May 2022:
-</p>
-<ol>
- <li><a href="#sharedImages">Hover images from ISharedImages</a></li>
-</ol>
-
-<p>
-Planned API removals after June 2022:
-</p>
-<ol>
- <li><a href="#icu4j">ICU4J bundle from SDK</a></li>
-</ol>
-
-<p>
-Planned API removals after March 2023:
-</p>
-<ol>
- <li><a href="#MultiPageEditor">MultiPageEditor</a></li>
- <li><a href="#pack200">Pack200</a></li>
-</ol>
-
-<p>
-Planned API removals after September 2023:
-</p>
-<ol>
- <li><a href="#ClassicSearch">Classic Search API</a></li>
-</ol>
-
-
-
-<hr>
-<!-- ############################################## -->
-
-<h2>API removals in the Eclipse 4.6 release</h2>
-
-<h3 id="runtime">1. Eclipse 2.0 runtime model and boot API</h3>
-<p>
-When the Eclipse runtime transitioned to use OSGi as its implementation, some existing
-APIs for interacting with the old runtime were deprecated and moved to a compatibility fragment
-(<code>org.eclipse.core.runtime.compatibility</code>). All API that was still valid was moved
-elsewhere. These APIs have been non-functional since Eclipse 3.0 and will therefore
-be removed in the future. The following packages will be removed:
-</p>
-<ul>
- <li>org.eclipse.core.boot</li>
- <li>org.eclipse.core.runtime.model</li>
- </ul>
- The compatibility fragment, <code>org.eclipse.core.runtime.compatibility</code> will
- also be removed. As a consequence <code>org.eclipse.ui.startup</code> extensions will no longer work if they do not specify a class that implements <code> org.eclipse.ui.IStartup</code>.
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=370248" target="_blank">bug 370248</a>.
-</p>
-
-<h2>API removals in the Eclipse 4.7 release</h2>
-
-<h3 id="listenerlist">1. org.eclipse.jface.util.ListenerList</h3>
-<p>
-The <code>org.eclipse.jface.util.ListenerList</code> class is deprecated since 2005 and has been replaced by <code>org.eclipse.core.runtime.ListenerList with org.eclipse.core.runtime.ListenerList.IDENTITY</code> as argument.
-The <code>org.eclipse.jface.util.ListenerList</code> class is planned to get deleted.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=436448" target="_blank">bug 436448</a>.
-</p>
-
-
-<!-- ############################################## -->
-
-<h2>API removals in the Eclipse 4.8 release</h2>
-
-<h3 id="updatemanager">1. Update Manager</h3>
-<p>
-Bundle org.eclipse.update.core from the old update manager API was removed.
-This API was marked for deletion in the 4.2. release via <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=311590" target="_blank">bug 311590</a>.
-</p>
-
- <h3 id="platform-methods">2. Methods in Platform deleted</h3>
-<p>
-
-Platform API as announced for Eclipse 4.2 was deleted.
-This API was marked for deletion in the 4.2. release via <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=476404" target="_blank">bug 476404</a>.
-The following methods are removed:
-</p>
-<ul>
- <li>Platform#addAuthorizationInfo</li>
- <li>Platform#getAuthorizationInfo</li>
- <li>Platform#flushAuthorizationInfo</li>
- <li>Platform#addProtectionSpace</li>
- <li>Platform#getProtectionSpace</li>
- </ul>
-
-<h3 id="tasklist">3. org.eclipse.ui.views.tasklist.TaskList</h3>
-<p>
-The <code>org.eclipse.ui.views.tasklist.TaskList</code> class is deprecated since Eclipse 3.4 and has been replaced by <code>MarkerSupportView</code>.
-The <code>org.eclipse.ui.views.tasklist.TaskList</code> class and related classes only used by this class are planned to get deleted.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=436506" target="_blank">bug 436506</a>.
-</p>
-
-<h3 id="icontextcomputer">4. IContextComputer and related classes</h3>
-<p>
-The <code>org.eclipse.ui.help.IContextComputer</code> class and dependent classes, i.e., org.eclipse.ui.help.WorkbenchHelp, DialogPageContextComputer and ViewContextComputer have been deleted. They were deprecated since 2002.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=442961" target="_blank">bug 442961</a>.
-</p>
-
-<!-- ############################################## -->
-
-<h2>API removals in the Eclipse 4.10 release</h2>
-
- <h3 id="tabletreeviewer">1. TableTreeViewer</h3>
-<p>
-The <code>org.eclipse.jface.viewers.TableTreeViewer</code> class is deprecated since Eclipse 3.1 and has been replaced by <code>TreeViewer</code>.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=540481" target="_blank">bug 436505</a>.
-</p>
-
-
-<!-- ############################################## -->
-
-<h2>API removals in the Eclipse 4.11 release</h2>
-
- <h3 id="imageandmessagearea">1. ImageAndMessageArea from JFace</h3>
-<p>
-The <code>org.eclipse.jface.dialogs.ImageAndMessageArea</code> class has been removed.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=475863" target="_blank">bug 475863</a>.
-</p>
-
-
-
-<!-- ############################################## -->
-
-<h2>API removals in the Eclipse 4.12 release</h2>
-
- <h3 id="iplugindescriptor">1. Delete IPluginDescriptor and related API</h3>
-<p>
-The <code>IPluginDescriptor</code> class has been removed.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=475944" target="_blank">bug 475944</a>.
-</p>
-
-<h3 id="tabletree">2. TableTree</h3>
-<p>
-The <code>org.eclipse.swt.custom.TableTree</code> and <code>org.eclipse.swt.custom.TableTreeItem</code> classes have been deleted as well as methods using these types.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=475833" target="_blank">bug 475833</a>.
-</p>
-
-
-<!-- ############################################## -->
-<h2>API removals in the Eclipse 4.17 release</h2>
-
-<h3 id="minputpart">1. Remove Input and MInputPart</h3>
-<p>
-The <code>MInput</code> and <code>MInputPart</code> classes and related API are removed.
-</p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=562813" target="_blank">bug 562813</a>.
-
-
-<h3 id="platform-getjobmanager">2. Remove method org.eclipse.core.runtime.Platform#getJobManager()</h3>
-
-The method <code>getJobManager()</code> is planned to be removed from class <code>org.eclipse.core.runtime.Platform</code>.
-Clients are encouraged to use the method <code>org.eclipse.core.runtime.jobs.Job#getJobManager()</code> instead.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=564893" target="_blank">bug 564893</a>.
-</p>
-
-
-
-<h3 id="jfaceassert">3. org.eclipse.jface.util.Assert and org.eclipse.jface.text.Assert</h3>
-<p>
-The <code>org.eclipse.jface.util.Assert</code> and <code>org.eclipse.jface.text.Assert</code> classes are removed.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=564891" target="_blank">bug 564891</a>.
-</p>
-
-
-<!-- ############################################## -->
-<h2>API removals in the Eclipse 4.19 release</h2>
-
-<h3 id="imodelprovider">1. org.eclipse.pde.core.IModelProvider</h3>
-
-The <code>org.eclipse.pde.core.IModelProvider</code> interface has been removed in 4.19.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=541068" target="_blank">bug 541068</a>.
-</p>
-
-
-<!-- ############################################## -->
-<h2>API removals in the Eclipse 4.20 release</h2>
-
-<h3 id="jobcreateSystem">1. Delete Job.createSystem(ICoreRunnable) API</h3>
-
-The <code>Job#createSystem(ICoreRunnable)</code> will be deleted.  Use <code>JobcreateSystem(String, ICoreRunnable)</code> instead.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=531968" target="_blank">bug 531968</a>.
-</p>
-
-
-<h3 id="iplatformrunnable">2. org.eclipse.core.runtime.IPlatformRunnable</h3>
-<p>
-The <code>org.eclipse.core.runtime.IPlatformRunnable</code> interface is planned to be removed.
-</p>
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=457134" target="_blank">bug 457134</a>.
-</p>
-
-
-<h3 id="targetProvisioners">3. Remove org.eclipse.pde.ui.targetProvisioners extension point</h3>
-
-The <code>org.eclipse.pde.ui.targetProvisioners</code> extension point is planned to be removed.
-
-Clients should use the <code>org.eclipse.pde.ui.targetLocationProvisioners</code> extension point instead.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=541806" target="_blank">bug 541806</a>.
-</p>
-
-<h3 id="20supportclasses">4. Delete 2.0 plug-in compatibility classes and related API</h3>
-
-The following classes and its related API will be deleted.
-
-<ul>
- <li>ILibrary</li>
- <li>IPluginPrerequisite</li>
- <li>IPluginRegistry</li>
-</ul>
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=544339" target="_blank">bug 544339</a>.
-</p>
-
-<!-- ############################################## -->
-<h2>API removals in the Eclipse 4.24 release</h2>
-
-<h3 id="bookmark">1. BookmarkNavigator view and related API</h3>
-
-BookmarkNavigator view (ResourceNavigator impl) and related API is marked for deletion.
-
-<p>
-For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578786" target="_blank">bug 578786</a>.
-</p>
-
-
-<hr/>
 
 
 
@@ -722,6 +352,238 @@ The "Classic" Search View and related API were deprecated in Eclipse 3.0 and are
 <p>
 For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=487303" target="_blank">bug 487303</a>.
 </p>
+
+
+
+<h1 id="removed">Removed API in previous releases</h1>
+
+
+<hr>
+<!-- ############################################## -->
+
+<h2>API removals in the Eclipse 4.6 release</h2>
+
+<h3 id="runtime">1. Eclipse 2.0 runtime model and boot API</h3>
+<p>
+When the Eclipse runtime transitioned to use OSGi as its implementation, some existing
+APIs for interacting with the old runtime were deprecated and moved to a compatibility fragment
+(<code>org.eclipse.core.runtime.compatibility</code>). All API that was still valid was moved
+elsewhere. These APIs have been non-functional since Eclipse 3.0 and will therefore
+be removed in the future. The following packages will be removed:
+</p>
+<ul>
+ <li>org.eclipse.core.boot</li>
+ <li>org.eclipse.core.runtime.model</li>
+ </ul>
+ The compatibility fragment, <code>org.eclipse.core.runtime.compatibility</code> will
+ also be removed. As a consequence <code>org.eclipse.ui.startup</code> extensions will no longer work if they do not specify a class that implements <code> org.eclipse.ui.IStartup</code>.
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=370248" target="_blank">bug 370248</a>.
+</p>
+
+<h2>API removals in the Eclipse 4.7 release</h2>
+
+<h3 id="listenerlist">1. org.eclipse.jface.util.ListenerList</h3>
+<p>
+The <code>org.eclipse.jface.util.ListenerList</code> class is deprecated since 2005 and has been replaced by <code>org.eclipse.core.runtime.ListenerList with org.eclipse.core.runtime.ListenerList.IDENTITY</code> as argument.
+The <code>org.eclipse.jface.util.ListenerList</code> class is planned to get deleted.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=436448" target="_blank">bug 436448</a>.
+</p>
+
+
+<!-- ############################################## -->
+
+<h2>API removals in the Eclipse 4.8 release</h2>
+
+<h3 id="updatemanager">1. Update Manager</h3>
+<p>
+Bundle org.eclipse.update.core from the old update manager API was removed.
+This API was marked for deletion in the 4.2. release via <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=311590" target="_blank">bug 311590</a>.
+</p>
+
+ <h3 id="platform-methods">2. Methods in Platform deleted</h3>
+<p>
+
+Platform API as announced for Eclipse 4.2 was deleted.
+This API was marked for deletion in the 4.2. release via <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=476404" target="_blank">bug 476404</a>.
+The following methods are removed:
+</p>
+<ul>
+ <li>Platform#addAuthorizationInfo</li>
+ <li>Platform#getAuthorizationInfo</li>
+ <li>Platform#flushAuthorizationInfo</li>
+ <li>Platform#addProtectionSpace</li>
+ <li>Platform#getProtectionSpace</li>
+ </ul>
+
+<h3 id="tasklist">3. org.eclipse.ui.views.tasklist.TaskList</h3>
+<p>
+The <code>org.eclipse.ui.views.tasklist.TaskList</code> class is deprecated since Eclipse 3.4 and has been replaced by <code>MarkerSupportView</code>.
+The <code>org.eclipse.ui.views.tasklist.TaskList</code> class and related classes only used by this class are planned to get deleted.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=436506" target="_blank">bug 436506</a>.
+</p>
+
+<h3 id="icontextcomputer">4. IContextComputer and related classes</h3>
+<p>
+The <code>org.eclipse.ui.help.IContextComputer</code> class and dependent classes, i.e., org.eclipse.ui.help.WorkbenchHelp, DialogPageContextComputer and ViewContextComputer have been deleted. They were deprecated since 2002.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=442961" target="_blank">bug 442961</a>.
+</p>
+
+<!-- ############################################## -->
+
+<h2>API removals in the Eclipse 4.10 release</h2>
+
+ <h3 id="tabletreeviewer">1. TableTreeViewer</h3>
+<p>
+The <code>org.eclipse.jface.viewers.TableTreeViewer</code> class is deprecated since Eclipse 3.1 and has been replaced by <code>TreeViewer</code>.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=540481" target="_blank">bug 436505</a>.
+</p>
+
+
+<!-- ############################################## -->
+
+<h2>API removals in the Eclipse 4.11 release</h2>
+
+ <h3 id="imageandmessagearea">1. ImageAndMessageArea from JFace</h3>
+<p>
+The <code>org.eclipse.jface.dialogs.ImageAndMessageArea</code> class has been removed.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=475863" target="_blank">bug 475863</a>.
+</p>
+
+
+
+<!-- ############################################## -->
+
+<h2>API removals in the Eclipse 4.12 release</h2>
+
+ <h3 id="iplugindescriptor">1. Delete IPluginDescriptor and related API</h3>
+<p>
+The <code>IPluginDescriptor</code> class has been removed.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=475944" target="_blank">bug 475944</a>.
+</p>
+
+<h3 id="tabletree">2. TableTree</h3>
+<p>
+The <code>org.eclipse.swt.custom.TableTree</code> and <code>org.eclipse.swt.custom.TableTreeItem</code> classes have been deleted as well as methods using these types.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=475833" target="_blank">bug 475833</a>.
+</p>
+
+
+<!-- ############################################## -->
+<h2>API removals in the Eclipse 4.17 release</h2>
+
+<h3 id="minputpart">1. Remove Input and MInputPart</h3>
+<p>
+The <code>MInput</code> and <code>MInputPart</code> classes and related API are removed.
+</p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=562813" target="_blank">bug 562813</a>.
+
+
+<h3 id="platform-getjobmanager">2. Remove method org.eclipse.core.runtime.Platform#getJobManager()</h3>
+
+The method <code>getJobManager()</code> is planned to be removed from class <code>org.eclipse.core.runtime.Platform</code>.
+Clients are encouraged to use the method <code>org.eclipse.core.runtime.jobs.Job#getJobManager()</code> instead.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=564893" target="_blank">bug 564893</a>.
+</p>
+
+
+
+<h3 id="jfaceassert">3. org.eclipse.jface.util.Assert and org.eclipse.jface.text.Assert</h3>
+<p>
+The <code>org.eclipse.jface.util.Assert</code> and <code>org.eclipse.jface.text.Assert</code> classes are removed.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=564891" target="_blank">bug 564891</a>.
+</p>
+
+
+<!-- ############################################## -->
+<h2>API removals in the Eclipse 4.19 release</h2>
+
+<h3 id="imodelprovider">1. org.eclipse.pde.core.IModelProvider</h3>
+
+The <code>org.eclipse.pde.core.IModelProvider</code> interface has been removed in 4.19.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=541068" target="_blank">bug 541068</a>.
+</p>
+
+
+<!-- ############################################## -->
+<h2>API removals in the Eclipse 4.20 release</h2>
+
+<h3 id="jobcreateSystem">1. Delete Job.createSystem(ICoreRunnable) API</h3>
+
+The <code>Job#createSystem(ICoreRunnable)</code> will be deleted.  Use <code>JobcreateSystem(String, ICoreRunnable)</code> instead.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=531968" target="_blank">bug 531968</a>.
+</p>
+
+
+<h3 id="iplatformrunnable">2. org.eclipse.core.runtime.IPlatformRunnable</h3>
+<p>
+The <code>org.eclipse.core.runtime.IPlatformRunnable</code> interface is planned to be removed.
+</p>
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=457134" target="_blank">bug 457134</a>.
+</p>
+
+
+<h3 id="targetProvisioners">3. Remove org.eclipse.pde.ui.targetProvisioners extension point</h3>
+
+The <code>org.eclipse.pde.ui.targetProvisioners</code> extension point is planned to be removed.
+
+Clients should use the <code>org.eclipse.pde.ui.targetLocationProvisioners</code> extension point instead.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=541806" target="_blank">bug 541806</a>.
+</p>
+
+<h3 id="20supportclasses">4. Delete 2.0 plug-in compatibility classes and related API</h3>
+
+The following classes and its related API will be deleted.
+
+<ul>
+ <li>ILibrary</li>
+ <li>IPluginPrerequisite</li>
+ <li>IPluginRegistry</li>
+</ul>
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=544339" target="_blank">bug 544339</a>.
+</p>
+
+<!-- ############################################## -->
+<h2>API removals in the Eclipse 4.24 release</h2>
+
+<h3 id="bookmark">1. BookmarkNavigator view and related API</h3>
+
+BookmarkNavigator view (ResourceNavigator impl) and related API is marked for deletion.
+
+<p>
+For further details or to provide feedback on this change, see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=578786" target="_blank">bug 578786</a>.
+</p>
+
+
+<hr/>
+
 
 
 

--- a/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -32,6 +32,9 @@
   This section describes API removals that occurred in past releases, and upcoming removals in future releases.
 </p>
 
+<p>
+See also https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Fdeprecated-list.html&anchor=forRemoval which lists the API marked in code for removal.
+</p>
 
 
 <!-- ############################################## -->


### PR DESCRIPTION
Removal the manual created TOC which is not complete and therefore
misleading. Also updating this TOC is painful and it is not checked
during the release validation process (otherwise I would not miss
entries).

Also moves the deleted API to the end of the document, I assume the
people are not interested on what is to come, than the past deletions.
Also we have now only two links, one to the planned deletion, on the to
actual deletion.

See also https://github.com/eclipse-platform/.github/issues/22 for an
even simpler suggestion for API removals.