### PR TITLE
Update of links for API removals

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/porting/removals.html
+++ b/bundles/org.eclipse.platform.doc.isv/porting/removals.html
@@ -27,13 +27,13 @@
 <h1 id="planned">Planned Deprecated API removals</h1>
 
 <p>
-  Deprecated API can be marked for deletion.
-  See the <a href="http://wiki.eclipse.org/Eclipse/API_Central/Deprecation_Policy">policy</a> for the details.
+  Deprecated API can be marked for deletion.  
+  See the <a href="https://github.com/eclipse-platform/.github/wiki/PMC-project-guidelines#api-removal-process">policy</a> for the details.
   This section describes API removals that occurred in past releases, and upcoming removals in future releases.
 </p>
 
 <p>
-See also https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Fdeprecated-list.html&anchor=forRemoval which lists the API marked in code for removal.
+See also <a href="https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Fdeprecated-list.html&anchor=forRemoval">Java API planned be be removed</a>  which lists the API marked in code for removal.
 </p>
 
 


### PR DESCRIPTION
As the old wiki will be discontinued, adjust the links to the Github
wiki.