### PR TITLE
Add new JDT api option: COMPILER_IGNORE_UNNAMED_MODULE_FOR_SPLIT_PACKAGE 

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_options.htm
+++ b/bundles/org.eclipse.jdt.doc.isv/guide/jdt_api_options.htm
@@ -3309,6 +3309,21 @@ doesn't exist, is not legitimate, or is not visible (e.g. a referenced project i
 <td><b><a href="../reference/api/org/eclipse/jdt/core/JavaCore.html#WARNING">WARNING</a></b></td>
 </tr>
 <tr>
+<td colspan="2"><b>Ignore Unnamed Module for Split Package</b>
+(<b><a href=
+"../reference/api/org/eclipse/jdt/core/JavaCore.html#COMPILER_IGNORE_UNNAMED_MODULE_FOR_SPLIT_PACKAGE">COMPILER_IGNORE_UNNAMED_MODULE_FOR_SPLIT_PACKAGE</a></b>)</td>
+</tr>
+<tr valign="top">
+
+<td rowspan="2">With this option the compiler will deliberately accept programs violating JLS in a specific way. Instead the compiler will behave in accordance to the original, but unmaintained document <a href="https://openjdk.org/projects/jigsaw/spec/sotms/#the-unnamed-module">"The State of the Module System"</a> which indicates that different semantics had been intended.
+</td>
+<td><b><a href=
+"../reference/api/org/eclipse/jdt/core/JavaCore.html#ENABLED"><i>ENABLED</i></a></b></td>
+</tr>
+<tr valign="top">
+<td><b><a href="../reference/api/org/eclipse/jdt/core/JavaCore.html#DISABLED">DISABLED</a></b></td>
+</tr>
+<tr>
 <td colspan="2"><b>Set the timeout value for retrieving a method's parameter names from javadoc</b>
 (<b><a href=
 "../reference/api/org/eclipse/jdt/core/JavaCore.html#TIMEOUT_FOR_PARAMETER_NAME_FROM_ATTACHED_JAVADOC">TIMEOUT_FOR_PARAMETER_NAME_FROM_ATTACHED_JAVADOC</a></b>)</td>


### PR DESCRIPTION
See: https://github.com/eclipse-jdt/eclipse.jdt.core/pull/424