### PR TITLE
Simplify o.e.equinox.http.jetty doc builds

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/cbi_basedirs.properties
+++ b/bundles/org.eclipse.platform.doc.isv/cbi_basedirs.properties
@@ -22,5 +22,4 @@ eclipse.platform.swt.examples=../../../eclipse.platform.swt/examples
 eclipse.platform.ui.examples=../../../eclipse.platform.ui/examples
 
 eclipse.equinox.supplement=../../../rt.equinox.framework/bundles/org.eclipse.osgi/supplement
-eclipse.equinox.http.jetty=org.eclipse.equinox.http.jetty
 org.apache.ant.jar=org.apache.ant_*-lib/ant.jar.jar

--- a/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.platform.doc.isv/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 Touch documentation bundles for javadoc regeneration
 Touch documentation bundles for javadoc regeneration
 Touch documentation bundles for javadoc regeneration
+Touch for regeneration

--- a/bundles/org.eclipse.platform.doc.isv/pde_basedirs.properties
+++ b/bundles/org.eclipse.platform.doc.isv/pde_basedirs.properties
@@ -22,5 +22,4 @@ eclipse.platform.swt.examples=..
 eclipse.platform.ui.examples=..
 
 eclipse.equinox.supplement=../org.eclipse.equinox.supplement
-eclipse.equinox.http.jetty=org.eclipse.equinox.http.jetty_*
 org.apache.ant.jar=org.apache.ant_*/lib/ant.jar

--- a/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
+++ b/bundles/org.eclipse.platform.doc.isv/platformOptions.txt
@@ -107,7 +107,7 @@
 ;${eclipse.platform.ui.bundles}/org.eclipse.ui.workbench/Eclipse UI
 ;${eclipse.platform.ui.bundles}/org.eclipse.ui.workbench/Eclipse UI Editor Support
 ;${eclipse.platform.update}/org.eclipse.update.configurator/src
-;${rt.equinox.bundles.bundles}/${eclipse.equinox.http.jetty}/src
+;${rt.equinox.bundles.bundles}/org.eclipse.equinox.http.jetty/src
 ;${rt.equinox.bundles.bundles}/org.eclipse.equinox.app/osgi
 ;${rt.equinox.bundles.bundles}/org.eclipse.equinox.app/src
 ;${rt.equinox.bundles.bundles}/org.eclipse.equinox.bidi/src


### PR DESCRIPTION
Having property for it and dereference it later just increases the chance for smth going wrong.