### PR TITLE
Document new searching behavior of the Open Resource dialog

### DIFF
--- a/bundles/org.eclipse.platform.doc.user/reference/ref-dialog-open-resource.htm
+++ b/bundles/org.eclipse.platform.doc.user/reference/ref-dialog-open-resource.htm
@@ -13,29 +13,35 @@
   <p>This dialog allows you to browse the workbench for a file to open in an editor</p>
   <ul>
     <li>
-      <strong>Select an item to open</strong>: In this field, type the first few characters of the name of the file you
-      want to select.
+      <strong>Select an item to open</strong>: In this field, type a few characters of the name of the file you
+      want to select. By default, the input pattern is searched <em>anywhere</em> in the file name and
+      with the exception of "Camel case" pattern (see below), the search is <em>case-insensitive</em>.
       <p>The following pattern kinds are supported:</p><br>
       <strong>Wildcards</strong>:<br>
       <ul>
         <li>"*" for any string and "?" for any character</li>
-        <li>terminating "&lt;" or " " (space) to prevent the automatic prefix matching, e.g. "M*file&lt;" to match
-        <code>Makefile</code> and <code>MockFile</code> but not <code>MakeTheFiles</code></li>
+        <li>leading "&gt;" to force matching from the start, e.g. "&gt;rea" to match
+          <code>README.txt</code>, but not <code>creators.txt</code></li>
+        <li>terminating "&lt;" or " " (space) to force matching at the end, e.g. "M*file&lt;" to match
+          <code>Makefile</code> and <code>xMockFile</code>, but not <code>xMockFiles</code></li>
       </ul><strong>Camel case</strong>:<br>
       <ul>
         <li>"CS" for file names containing "C" and "S" as upper-case letters in camel-case notation, e.g.
         <code>CreateStuff.java</code></li>
         <li>"CreSNo" for file names containing "Cre", "S", and "No" as parts in camel-case notation, e.g.
         <code>CreateStuffNow.jsp</code></li>
-        <li>terminating "&lt;" or " " (space) to fix the number of camel-case parts, e.g. "CreS&lt;" matches
-        "CreateStuff.java", but not "CreateStuffNow.jsp" nor "Createstuff.txt".</li>
+        <li>leading "&gt;" to force matching from the start, e.g. "&gt;CreS" to match
+          <code>CreateStuff.java</code>, but not <code>DoCreateStuff.java</code></li>
+        <li>terminating "&lt;" or " " (space) to fix the number of camel-case parts, e.g. CreS&lt;" to match
+          <code>CreateStuff.java</code>, but not <code>CreateStuffNow.jsp</code> nor <code>Createstuff.txt</code></li>
       </ul><strong>Folder prefixes</strong>:<br>
       <p>Both pattern kinds also support <strong>folder prefixes</strong>. If the pattern contains a /, the part before
       the last / is used to match a path in the workspace, e.g. "org.eclipse.ui/plugin.xml".<br>
       Or a bit more complex: "*/ui&lt;/pack*.html" matches e.g. files called "package.html" in a folder named "ui" (but
       not in folders like "uitools" or "*/ui/internal").</p><br>
       <strong>Relative paths</strong>:<br>
-      <p>For example, "./Mak" matches all files starting with "Mak" in the folder of the active editor or selection,
+      <p>For example, "./Mak" matches all files which have "Mak" in their name
+        and are in the folder of the active editor or selection,
       while "../Mak" matches such files in the parent folder.</p><br>
     </li>
     <li>


### PR DESCRIPTION
This covers changes implemented here:
https://github.com/eclipse-platform/eclipse.platform.ui/pull/12. In short, automatic prefix ("starts with") search got replaced with automatic infix ("contains") search. Also, a new wildcard character '>' was introduced to enforce the original prefix search.

To improve the docs at the same time:

* mention explicitly that the search is case-insensitive
* unify the way example searches are formulated