### PR TITLE
Fix JDT javadoc build

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -2,9 +2,9 @@
 -encoding "UTF-8"
 -charset "UTF-8"
 -sourcepath "${eclipse.jdt.core}/org.eclipse.jdt.annotation/src
+;${eclipse.jdt.core}/org.eclipse.jdt.core.compiler.batch/src
 ;${eclipse.jdt.core}/org.eclipse.jdt.apt.core/src
 ;${eclipse.jdt.core}/org.eclipse.jdt.core/antadapter
-;${eclipse.jdt.core}/org.eclipse.jdt.core/batch
 ;${eclipse.jdt.core}/org.eclipse.jdt.core/codeassist
 ;${eclipse.jdt.core}/org.eclipse.jdt.core/compiler
 ;${eclipse.jdt.core}/org.eclipse.jdt.core/dom


### PR DESCRIPTION
Follow up fix after
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/181