### PR TITLE
Fixed copy/paste error for 4.26

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
+++ b/bundles/org.eclipse.platform.doc.isv/topics_Porting.xml
@@ -9,7 +9,7 @@
 		<topic label="Introduction" href="porting/eclipse_4_26_porting_guide.html"/>
 		<topic label="FAQ" href="porting/4.26/faq.html" />
 		<topic label="Incompatibilities" href="porting/4.26/incompatibilities.html" />
-		<topic label="Adopting 4.25 mechanisms and API" href="porting/4.26/recommended.html" />
+		<topic label="Adopting 4.26 mechanisms and API" href="porting/4.26/recommended.html" />
 	</topic>
 	<topic label="Migrating to Eclipse 4.25 from 4.24">
 		<topic label="Introduction" href="porting/eclipse_4_25_porting_guide.html"/>


### PR DESCRIPTION
"Adopting 4.25 mechanisms and API" -> "Adopting 4.26 mechanisms and API"