### PR TITLE
Add indirect org.eclipse.equinox.concurrent dependency

### DIFF
--- a/bundles/org.eclipse.platform.doc.isv/pom.xml
+++ b/bundles/org.eclipse.platform.doc.isv/pom.xml
@@ -256,6 +256,11 @@
                     <id>org.osgi.annotation.versioning</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.equinox.concurrent</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
                 </extraRequirements>
               </dependency-resolution>
             </configuration>


### PR DESCRIPTION
Currently the ISV build only transitivly depends on org.eclipse.equinox.concurrent as a reactor project, with the new resolver such setup will be considdered as an error so it is better to make it explicit now.