### PR TITLE
version bumps for 4.28 stream: eclipse-platform.common

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jdt.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.isv; singleton:=true
-Bundle-Version: 3.14.1900.qualifier
+Bundle-Version: 3.14.2000.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.jdt.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.doc.user; singleton:=true
-Bundle-Version: 3.15.1700.qualifier
+Bundle-Version: 3.15.1800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"

--- a/bundles/org.eclipse.jdt.doc.user/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.user/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.doc.user</artifactId>
-  <version>3.15.1700-SNAPSHOT</version>
+  <version>3.15.1800-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <profiles>
     <profile>

--- a/bundles/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.pde.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.doc.user; singleton:=true
-Bundle-Version: 3.14.1900.qualifier
+Bundle-Version: 3.14.2000.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"


### PR DESCRIPTION
Version bumps for 4.28 stream in the platform-common repo

Fixes: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/917