### PR TITLE
Make jdt javadoc generation a bit more verbose

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/buildDoc.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/buildDoc.xml
@@ -103,8 +103,8 @@
 		<property name="replaceFile" value="target/jdtOptions.replace.txt" />
 		<echo file="${basedir}/${replaceFile}">${fileList}&#xA;&#xA;${dirList}&#xA;&#xA;</echo>
 
-<echo>org.eclipse.jdt.doc.isv/buildDoc.xml - generateJavadoc:
-      Using javadocExecutable: ${javadocExecutable}</echo>
+		<echo>org.eclipse.jdt.doc.isv/buildDoc.xml - generateJavadoc:</echo>
+		<echo>Using java home: ${java.home} and javadocExecutable: ${javadocExecutable}</echo>
 <!--
 <echo>${basedir}/${replaceFile} before _* expansion:</echo>
 <concat><filelist files="${basedir}/${replaceFile}"></filelist></concat>

--- a/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -99,7 +99,6 @@
 	                  <args>target/workspace</args>
 	                  <args>-application</args>
 	                  <args>org.eclipse.ant.core.antRunner</args>
-	                  <args>-quiet</args>
 	                  <args>-buildfile</args>
 	                  <args>buildDoc.xml</args>
 	                  <args>-Dbasedir.properties=cbi_basedirs.properties</args>


### PR DESCRIPTION
- Remove "-quiet" ant argument from org.eclipse.jdt.doc.isv
- print java.home additionally to used javadocExecutable

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/484