### PR TITLE
Disable org.eclipse.ant.launching javadoc build

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -29,7 +29,6 @@
 ;${eclipse.jdt.ui}/org.eclipse.jdt.ui/internal compatibility
 ;${eclipse.jdt.ui}/org.eclipse.jdt.ui/ui
 ;${eclipse.jdt.ui}/org.eclipse.jdt.ui/ui refactoring
-;${eclipse.platform.ant}/org.eclipse.ant.launching/src
 ;${eclipse.platform.ant}/org.eclipse.ant.ui/Ant Editor
 ;${eclipse.platform.ant}/org.eclipse.ant.ui/Ant Tools Support"
 -d reference/api
@@ -109,8 +108,7 @@
 -group "Java development tools APT packages" "org.eclipse.jdt.apt.core
 ;org.eclipse.jdt.apt.core.*
 ;com.sun.mirror.*"
--group "Java development tools debug and launching packages" "org.eclipse.ant.launching
-;org.eclipse.ant.ui.launching
+-group "Java development tools debug and launching packages" "org.eclipse.ant.ui.launching
 ;org.eclipse.jdt.debug.*
 ;org.eclipse.jdt.launching
 ;org.eclipse.jdt.launching.*"
@@ -170,7 +168,6 @@ org.eclipse.jdt.apt.core.build
 org.eclipse.jdt.apt.core.env
 org.eclipse.jdt.apt.core.util
 
-org.eclipse.ant.launching
 org.eclipse.ant.ui.launching
 org.eclipse.jdt.debug.core
 org.eclipse.jdt.debug.eval


### PR DESCRIPTION
It fails always with following error:

```
../../../eclipse.platform/ant/org.eclipse.ant.launching/src/org/eclipse/ant/launching/IAntLaunchConstants.java:17:
error: package org.eclipse.core.externaltools.internal does not exist
import org.eclipse.core.externaltools.internal.IExternalToolConstants;
                                              ^
1 error
```

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/484