### PR TITLE
Revert "Disable org.eclipse.ant.launching javadoc build"

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
+++ b/bundles/org.eclipse.jdt.doc.isv/jdtOptions.txt
@@ -29,6 +29,7 @@
 ;${eclipse.jdt.ui}/org.eclipse.jdt.ui/internal compatibility
 ;${eclipse.jdt.ui}/org.eclipse.jdt.ui/ui
 ;${eclipse.jdt.ui}/org.eclipse.jdt.ui/ui refactoring
+;${eclipse.platform.ant}/org.eclipse.ant.launching/src
 ;${eclipse.platform.ant}/org.eclipse.ant.ui/Ant Editor
 ;${eclipse.platform.ant}/org.eclipse.ant.ui/Ant Tools Support"
 -d reference/api
@@ -108,7 +109,8 @@
 -group "Java development tools APT packages" "org.eclipse.jdt.apt.core
 ;org.eclipse.jdt.apt.core.*
 ;com.sun.mirror.*"
--group "Java development tools debug and launching packages" "org.eclipse.ant.ui.launching
+-group "Java development tools debug and launching packages" "org.eclipse.ant.launching
+;org.eclipse.ant.ui.launching
 ;org.eclipse.jdt.debug.*
 ;org.eclipse.jdt.launching
 ;org.eclipse.jdt.launching.*"
@@ -168,6 +170,7 @@ org.eclipse.jdt.apt.core.build
 org.eclipse.jdt.apt.core.env
 org.eclipse.jdt.apt.core.util
 
+org.eclipse.ant.launching
 org.eclipse.ant.ui.launching
 org.eclipse.jdt.debug.core
 org.eclipse.jdt.debug.eval


### PR DESCRIPTION
This reverts commit 70a7900e544c925cc7a82c9145b38dbc5f0d6620.

The change didn't had any effect.