### PR TITLE
Add org.eclipse.core.externaltools dependency to maven config

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -56,6 +56,11 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
+                    <id>org.eclipse.core.externaltools</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
                     <id>com.ibm.icu</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>


### PR DESCRIPTION
This makes sure the org.eclipse.core.externaltools is built before the javadoc is executed, so it's target/classes directory is not empty and javadoc sees the required classes used by JDT.

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/484