### PR TITLE
Add more dependencies to maven config

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/pom.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/pom.xml
@@ -61,6 +61,41 @@
                   </requirement>
                   <requirement>
                     <type>eclipse-plugin</type>
+                    <id>org.eclipse.jdt.junit</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.ui.console</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.ltk.ui.refactoring</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.ui.workbench</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.ui.ide</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.help.ui</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
+                    <id>org.eclipse.equinox.app</id>
+                    <versionRange>0.0.0</versionRange>
+                  </requirement>
+                  <requirement>
+                    <type>eclipse-plugin</type>
                     <id>com.ibm.icu</id>
                     <versionRange>0.0.0</versionRange>
                   </requirement>


### PR DESCRIPTION
This makes sure the dependencies are built before the javadoc is executed, so it's target/classes directory is not empty and javadoc sees the required classes used by JDT.

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/484