### PR TITLE
Provide documentation for the p2's new TrustAuthorityDialog

### DIFF
--- a/bundles/org.eclipse.platform.doc.user/contexts_P2.xml
+++ b/bundles/org.eclipse.platform.doc.user/contexts_P2.xml
@@ -50,7 +50,11 @@
        <topic label="Preferences - Automatic Updates" href="reference/ref-p2-autoupdate.htm"/>
     </context>
     <context id="trust_dialog_context">
-       <description>This page allows you to review the certificates and PGP keys of the signatures of the artifacts being installed to decide whether to trust some of them in order to complete the installation.</description>
+       <description>This dialog allows you to review the certificates and PGP keys of the signatures of the artifacts being installed to decide whether to trust some of them in order to complete the installation.</description>
        <topic href="reference/ref-p2-trust.htm" label="Trusting signers"/>
+    </context>
+    <context id="trust_authorities_dialog_context">
+       <description>This dialog allows you to review the originating sites of the content being installed to decide whether to trust those authorities in order to complete the installation.</description>
+       <topic href="reference/ref-p2-trust-authority.htm" label="Trusting authorities"/>
     </context>
 </contexts>

--- a/bundles/org.eclipse.platform.doc.user/reference/ref-p2-trust-authority.htm
+++ b/bundles/org.eclipse.platform.doc.user/reference/ref-p2-trust-authority.htm
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+  <meta name="copyright" content=
+  "Copyright (c) Red Hat Inc. and others 2022. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page.">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+  <script language="JavaScript" src="PLUGINS_ROOT/org.eclipse.help/livehelp.js" type="text/javascript"></script>
+  <title>Trust</title>
+</head>
+<body bgcolor="#FFFFFF">
+
+<h1 class="Head">Trusting p2 content installation</h1>
+<p class="Intro">
+Installing content is by nature a security risk as it can reconfigure the installation and can do so for potentially malicious purposes.
+This is the case even when installing content that has no associated associated artifact.
+To mitigate this risk, p2 tracks the originating external sources of all content being installed and presents that information for review.
+</p>
+
+<h2>Trust Authorities Dialog</h2>
+<p>
+External content is typically installed via an <code>https</code> connection that ensures that the content is security transported from the content authority to the receiver.
+This <strong>does not guarantee</strong> that the content is trustworthy.
+The user is encouraged to consider carefully whether the site and associated authority from which content is being downloaded is actually trustworthy.
+<p>
+
+<p>
+In the case of content being installed from an unverified site or authority, 
+the <em>Trust Authorities</em> dialog shows the units being installed along with the associated sites and authorities from which those units originate for the user's review and approval.
+The details of the so-called touch-points of each such unit present any configuration instructions that will be applied during installation.
+The user may choose which authorities are trusted, and may even choose to install content from all authorities in the future.
+If all the units originate from trusted authorities, installation will continue; otherwise it's aborted.
+</p>
+
+<h2>Trust Preference Page</h2>
+<p>
+The
+<a class="command-link" href='javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.equinox.internal.p2.ui.sdk.TrustPreferencePage)")'>
+  <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link">
+  <strong>Install/Update &gt; Trust</strong>
+</a>
+preference page's <strong>Authorities</strong> tab lists all the authorities considered as trusted and allows to add or remove authorities,
+or even to allow all content from all authorities to be installed without confirmation.
+</p>
+
+<h3 class="related">Related tasks</h3>
+<a href="../tasks/tasks-120.htm">Updating the installation</a><br>
+<a href="../tasks/tasks-124.htm">Installing new software</a><br>
+<a href="ref-p2-trust.htm">Trusting p2 artifact installation</a>
+
+<h3 class="related">Related reference</h3>
+<a href="ref-61.htm">Help Menu</a>
+
+</body>
+</html>

--- a/bundles/org.eclipse.platform.doc.user/reference/ref-p2-trust.htm
+++ b/bundles/org.eclipse.platform.doc.user/reference/ref-p2-trust.htm
@@ -10,37 +10,51 @@
   <title>Trust</title>
 </head>
 <body bgcolor="#FFFFFF">
-  <h1 class="Head">Trusting p2 installations</h1>
-  <p class="Intro">Installing artifacts is by nature a security risk as it will then allow the artifacts to execute
-  potentially malicious code. To mitigate this risk, p2 does verify artifact <b>signatures</b> during installations and
-  warns of any discrepancy.</p>
-  <h2>Unsigned artifacts warning</h2>
-  <p>If some artifacts have no digital signatures attached (using <code>jarsigner</code> or PGP signing technologies),
-  the <em>Unsigned artifacts</em> dialog pops-up to warn that there is no signature for those artifacts.</p>
-  <p>An artifact without a signature can easily be tampered so that the artifact being installed contains different
-  content as what's expected during installation. So artifacts without signatures are a security thread and
-  installating them is a risky action, much care should be taken before approving such installation.</p>
-  <p>The pop-up allows to abort installation, or to take the risk of installing an installed artifact and continue
-  installation.</p>
-  <h2>Trust Dialog</h2>
-  <p>One of the main goal of signatures is to match a signer identity to an artifact, so that in order to trust an
-  artifact, a user can simply decide whether they trust the signer. It's usually an easier decision to take.</p>
-  <p>Sometimes, all artifacts have a signature but the identity of the signer is not know whether it can be trusted or
-  not. The strategy to decide whether a signer can be trusted or not is up to the user; different users can have
-  different workflows to decide whether to trust a signer or not.</p>
-  <p>In such case, the <em>Trust</em> dialog shows the list of certificates or PGP public keys along with extra
-  information to let user define whether those can be trusted (Is the key itself trust? If yes, do I trust the
-  signer?...).</p>
-  <p>If all artifacts are signed by at least 1 trusted key or certificate, installation will continue; otherwise it's
-  aborted.</p>
-  <h2>Trust Preference Page</h2>
-  <p><a class="command-link" href=
-  'javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdatesPreferencePage)")'>
-  <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link"> <strong>Install/Update &gt;
-  Trust</strong></a> preference page lists all the PGP public keys that are considered as already trusted and allows to
-  add or remove some.</p>
-  <h3 class="related">Related tasks</h3><a href="../tasks/tasks-120.htm">Updating the installation</a><br>
-  <a href="../tasks/tasks-124.htm">Installing new software</a>
-  <h3 class="related">Related reference</h3><a href="ref-61.htm">Help Menu</a>
+
+<h1 class="Head">Trusting p2 artifact installation</h1>
+<p class="Intro">
+Installing artifacts is by nature a security risk as it will allow the artifacts to execute potentially malicious code.
+To mitigate this risk, p2 verifies artifact <b>signatures</b> during installation and selectively prompts for artifact trust.
+</p>
+
+<h2>Trust Artifacts Dialog</h2>
+<p>
+One of the main goals of digital signatures is to match a signer identity to each artifact,
+such that trusting an artifact is simply a decision of whether to trust the signer.
+</p>
+
+<p>
+Often all artifacts have a signature but the identity of each signer may not be known.
+Artifacts signed by a X509 certificate rooted in the Java runtime's trust store are trusted by default.
+Artifacts signed by a PGP public key are trusted only if that key is trusted in the preferences.
+Unsigned artifacts are always treated as untrusted;
+such an artifact can be relatively easily tampered such that the artifact being installed contains different content than expected.
+</p>
+
+<p>
+In the case of unverified artifact signers or unsigned artifacts, the <em>Trust Artifacts</em> dialog shows the artifacts along with associated certificates and PGP public keys, if any, for the user's review and approval.
+The user may choose which signers are trusted, and may even choose to install unsigned content.
+If all artifacts are signed by at least 1 trusted key or certificate or if unsigned artifacts are permitted, installation will continue; otherwise it's aborted.
+</p>
+
+<h2>Trust Preference Page</h2>
+<p>
+The
+<a class="command-link" href='javascript:executeCommand("org.eclipse.ui.window.preferences(preferencePageId=org.eclipse.equinox.internal.p2.ui.sdk.TrustPreferencePage)")'>
+  <img src="PLUGINS_ROOT/org.eclipse.help/command_link.svg" alt="command link">
+  <strong>Install/Update &gt; Trust</strong>
+</a>
+preference page's <strong>Artifacts</strong> tab lists all the certificates and PGP public keys that are considered as trusted and allows to add or remove certificates and keys,
+or even to allow all artifacts to be installed without confirmation.
+</p>
+
+<h3 class="related">Related tasks</h3>
+<a href="../tasks/tasks-120.htm">Updating the installation</a><br>
+<a href="../tasks/tasks-124.htm">Installing new software</a><br>
+<a href="ref-p2-trust-authority.htm">Trusting p2 content installation</a>
+
+<h3 class="related">Related reference</h3>
+<a href="ref-61.htm">Help Menu</a>
+
 </body>
 </html>


### PR DESCRIPTION
Also update the TrustCertificateDialog to better reflect the current implementation, to properly open the trust preferences and to cross reference the new help page.

https://github.com/eclipse-equinox/p2/issues/235