### PR TITLE
Stop declaring prebuilt index as it's no longer built

### DIFF
--- a/bundles/org.eclipse.jdt.doc.isv/plugin.xml
+++ b/bundles/org.eclipse.jdt.doc.isv/plugin.xml
@@ -15,7 +15,6 @@
 
    <extension point="org.eclipse.help.toc">
        <toc file="toc.xml" primary="true" />
-       <index path="index"/>
    </extension>
 
 <!-- ============================================================================= -->

--- a/bundles/org.eclipse.jdt.doc.user/plugin.xml
+++ b/bundles/org.eclipse.jdt.doc.user/plugin.xml
@@ -15,7 +15,6 @@
 
    <extension point="org.eclipse.help.toc">
        <toc file="toc.xml" primary="true" />
-       <index path="index"/>
    </extension>
 
 

--- a/bundles/org.eclipse.pde.doc.user/plugin.xml
+++ b/bundles/org.eclipse.pde.doc.user/plugin.xml
@@ -24,7 +24,6 @@
             primary="true"
             extradir="guide/intro">
       </toc>
-      <index path="index"/>
    </extension>
 <!-- ============================================================================= -->
 <!-- Define TOCs                                                                   -->

--- a/bundles/org.eclipse.platform.doc.isv/plugin.xml
+++ b/bundles/org.eclipse.platform.doc.isv/plugin.xml
@@ -15,7 +15,6 @@
             file="toc.xml"
             primary="true">
       </toc>
-      <index path="index"/>
    </extension>
 <!-- ============================================================================= -->
 <!-- Define TOCs                                                                   -->

--- a/bundles/org.eclipse.platform.doc.user/plugin.xml
+++ b/bundles/org.eclipse.platform.doc.user/plugin.xml
@@ -15,7 +15,6 @@
 
    <extension point="org.eclipse.help.toc">
        <toc file="toc.xml" primary="true" />
-       <index path="index"/>
    </extension>
 
 <!-- ============================================================================= -->


### PR DESCRIPTION
Continuation of
https://github.com/eclipse-platform/eclipse.platform.common/pull/159